### PR TITLE
Opened books separator

### DIFF
--- a/covermenu.lua
+++ b/covermenu.lua
@@ -268,7 +268,8 @@ function CoverMenu:onCloseWidget()
 end
 
 function CoverMenu:genItemTable(dirs, files, path)
-    is_pathchooser = ptutil.isPathChooser(self)
+    self.recent_boundary_index = nil
+
     if meta_browse_mode == true and is_pathchooser == false and G_reader_settings:readSetting("home_dir") ~= nil then
         -- build item tables from coverbrowser-style sqlite db
         local SQ3 = require("lua-ljsqlite3/init")
@@ -314,6 +315,7 @@ function CoverMenu:genItemTable(dirs, files, path)
                 end
             end
             if util.tableSize(items_place_at_top) > 0 then
+                self.recent_boundary_index = util.tableSize(items_place_at_top)
                 util.tableMerge(custom_item_table, items_place_at_top)
             end
         end

--- a/covermenu.lua
+++ b/covermenu.lua
@@ -270,9 +270,11 @@ end
 function CoverMenu:genItemTable(dirs, files, path)
     is_pathchooser = ptutil.isPathChooser(self)
     self.recent_boundary_index = 0
+    self.meta_show_opened = nil
 
     if meta_browse_mode == true and is_pathchooser == false and G_reader_settings:readSetting("home_dir") ~= nil then
         -- build item tables from coverbrowser-style sqlite db
+        if BookInfoManager:getSetting("opened_at_top_of_library") then self.meta_show_opened = true end
         local SQ3 = require("lua-ljsqlite3/init")
         local DataStorage = require("datastorage")
         local lfs = require("libs/libkoreader-lfs")

--- a/covermenu.lua
+++ b/covermenu.lua
@@ -317,7 +317,13 @@ function CoverMenu:genItemTable(dirs, files, path)
             end
             if util.tableSize(items_place_at_top) > 0 then
                 self.recent_boundary_index = util.tableSize(items_place_at_top)
-                util.tableMerge(custom_item_table, items_place_at_top)
+                local function join_tables(t1,t2)
+                    for i=1,#t2 do
+                        t1[#t1+1] = t2[i]
+                    end
+                    return t1
+                end
+                custom_item_table = join_tables(items_place_at_top, custom_item_table)
             end
         end
         self.db_conn:close()

--- a/covermenu.lua
+++ b/covermenu.lua
@@ -269,7 +269,7 @@ end
 
 function CoverMenu:genItemTable(dirs, files, path)
     is_pathchooser = ptutil.isPathChooser(self)
-    self.recent_boundary_index = nil
+    self.recent_boundary_index = 0
 
     if meta_browse_mode == true and is_pathchooser == false and G_reader_settings:readSetting("home_dir") ~= nil then
         -- build item tables from coverbrowser-style sqlite db
@@ -327,6 +327,7 @@ function CoverMenu:genItemTable(dirs, files, path)
             end
         end
         self.db_conn:close()
+        logger.info(self.recent_boundary_index)
         return custom_item_table
     else
         local item_table = CoverMenu._FileChooser_genItemTable_orig(self, dirs, files, path)

--- a/covermenu.lua
+++ b/covermenu.lua
@@ -719,7 +719,7 @@ function CoverMenu:menuInit()
             w = self.inner_dimen.w,
             h = self.inner_dimen.h - self.page_info:getSize().h,
         },
-        ptutil.darkLine(self.inner_dimen.w),
+        ptutil.mediumDarkLine(self.inner_dimen.w),
     }
     local footer = OverlapGroup:new {
         -- This unique allow_mirroring=false looks like it's enough

--- a/covermenu.lua
+++ b/covermenu.lua
@@ -327,7 +327,6 @@ function CoverMenu:genItemTable(dirs, files, path)
             end
         end
         self.db_conn:close()
-        logger.info(self.recent_boundary_index)
         return custom_item_table
     else
         local item_table = CoverMenu._FileChooser_genItemTable_orig(self, dirs, files, path)

--- a/covermenu.lua
+++ b/covermenu.lua
@@ -268,6 +268,7 @@ function CoverMenu:onCloseWidget()
 end
 
 function CoverMenu:genItemTable(dirs, files, path)
+    is_pathchooser = ptutil.isPathChooser(self)
     self.recent_boundary_index = nil
 
     if meta_browse_mode == true and is_pathchooser == false and G_reader_settings:readSetting("home_dir") ~= nil then

--- a/covermenu.lua
+++ b/covermenu.lua
@@ -720,7 +720,7 @@ function CoverMenu:menuInit()
             w = self.inner_dimen.w,
             h = self.inner_dimen.h - self.page_info:getSize().h,
         },
-        ptutil.mediumDarkLine(self.inner_dimen.w),
+        ptutil.mediumBlackLine(self.inner_dimen.w),
     }
     local footer = OverlapGroup:new {
         -- This unique allow_mirroring=false looks like it's enough

--- a/listmenu.lua
+++ b/listmenu.lua
@@ -1296,7 +1296,12 @@ function ListMenu:_updateItemsBuildUI()
             if not Device:isTouchDevice() or BookInfoManager:getSetting("force_focus_indicator") then
                 table.insert(self.item_group, VerticalSpan:new { width = Screen:scaleBySize(3) })
             end
-            table.insert(self.item_group, ptutil.lightLine(line_width))
+            local is_boundary_here = (self.recent_boundary_index and self.recent_boundary_index > 0 and index == self.recent_boundary_index + 1)
+            if is_boundary_here then
+                table.insert(self.item_group, ptutil.darkLine(line_width))
+            else
+                table.insert(self.item_group, ptutil.lightLine(line_width))
+            end
         end
         local item_tmp = ListMenuItem:new {
             height = self.item_height,

--- a/listmenu.lua
+++ b/listmenu.lua
@@ -1282,6 +1282,7 @@ function ListMenu:_updateItemsBuildUI()
     table.insert(self.item_group, ptutil.mediumBlackLine(line_width))
     local idx_offset = (self.page - 1) * self.perpage
     local select_number
+    if self.recent_boundary_index == nil then self.recent_boundary_index = 0 end
     for idx = 1, self.perpage do
         local itm_timer = ptdbg:new()
         local index = idx_offset + idx

--- a/listmenu.lua
+++ b/listmenu.lua
@@ -1279,7 +1279,7 @@ function ListMenu:_updateItemsBuildUI()
     -- Build our list
     local list_timer = ptdbg:new()
     local line_width = self.width or self.screen_w
-    table.insert(self.item_group, ptutil.mediumDarkLine(line_width))
+    table.insert(self.item_group, ptutil.mediumBlackLine(line_width))
     local idx_offset = (self.page - 1) * self.perpage
     local select_number
     for idx = 1, self.perpage do
@@ -1298,9 +1298,9 @@ function ListMenu:_updateItemsBuildUI()
             end
             local is_boundary_here = (self.recent_boundary_index and self.recent_boundary_index > 0 and index == self.recent_boundary_index + 1)
             if is_boundary_here then
-                table.insert(self.item_group, ptutil.thinDarkLine(line_width))
+                table.insert(self.item_group, ptutil.thinBlackLine(line_width))
             else
-                table.insert(self.item_group, ptutil.thinLightLine(line_width))
+                table.insert(self.item_group, ptutil.thinGrayLine(line_width))
             end
         end
         local item_tmp = ListMenuItem:new {

--- a/listmenu.lua
+++ b/listmenu.lua
@@ -1279,7 +1279,7 @@ function ListMenu:_updateItemsBuildUI()
     -- Build our list
     local list_timer = ptdbg:new()
     local line_width = self.width or self.screen_w
-    table.insert(self.item_group, ptutil.darkLine(line_width))
+    table.insert(self.item_group, ptutil.mediumDarkLine(line_width))
     local idx_offset = (self.page - 1) * self.perpage
     local select_number
     for idx = 1, self.perpage do
@@ -1298,9 +1298,9 @@ function ListMenu:_updateItemsBuildUI()
             end
             local is_boundary_here = (self.recent_boundary_index and self.recent_boundary_index > 0 and index == self.recent_boundary_index + 1)
             if is_boundary_here then
-                table.insert(self.item_group, ptutil.darkLine(line_width))
+                table.insert(self.item_group, ptutil.thinDarkLine(line_width))
             else
-                table.insert(self.item_group, ptutil.lightLine(line_width))
+                table.insert(self.item_group, ptutil.thinLightLine(line_width))
             end
         end
         local item_tmp = ListMenuItem:new {

--- a/listmenu.lua
+++ b/listmenu.lua
@@ -1291,16 +1291,17 @@ function ListMenu:_updateItemsBuildUI()
         if index == self.itemnumber then -- focused item
             select_number = idx
         end
+        local is_boundary_crossed = true
         if idx > 1 then
             -- add focus indicator padding only for devices that need it
             if not Device:isTouchDevice() or BookInfoManager:getSetting("force_focus_indicator") then
                 table.insert(self.item_group, VerticalSpan:new { width = Screen:scaleBySize(3) })
             end
-            local is_boundary_here = (self.recent_boundary_index and self.recent_boundary_index > 0 and index == self.recent_boundary_index + 1)
-            if is_boundary_here then
-                table.insert(self.item_group, ptutil.thinBlackLine(line_width))
-            else
+            is_boundary_crossed = (index - 1 >= self.recent_boundary_index + 1)
+            if is_boundary_crossed then
                 table.insert(self.item_group, ptutil.thinGrayLine(line_width))
+            else
+                table.insert(self.item_group, ptutil.thinBlackLine(line_width))
             end
         end
         local item_tmp = ListMenuItem:new {

--- a/mosaicmenu.lua
+++ b/mosaicmenu.lua
@@ -1280,7 +1280,7 @@ function MosaicMenu:_updateItemsBuildUI()
     -- Build our grid
     local grid_timer = ptdbg:new()
     local line_width = self.width or self.screen_w
-    table.insert(self.item_group, ptutil.darkLine(line_width))
+    table.insert(self.item_group, ptutil.mediumDarkLine(line_width))
     local cur_row = nil
     local idx_offset = (self.page - 1) * self.perpage
     local line_layout = {}
@@ -1299,7 +1299,7 @@ function MosaicMenu:_updateItemsBuildUI()
             table.insert(self.item_group, VerticalSpan:new { width = Screen:scaleBySize(half_margin_size) })
             if idx > 1 then
                 table.insert(self.layout, line_layout)
-                table.insert(self.item_group, ptutil.lightLine(line_width))
+                table.insert(self.item_group, ptutil.thinLightLine(line_width))
                 table.insert(self.item_group, VerticalSpan:new { width = Screen:scaleBySize(half_margin_size) })
             end
             line_layout = {}

--- a/mosaicmenu.lua
+++ b/mosaicmenu.lua
@@ -1285,6 +1285,7 @@ function MosaicMenu:_updateItemsBuildUI()
     table.insert(self.item_group, VerticalSpan:new { width = Screen:scaleBySize(half_margin_size) })
     local cur_row = nil
     local idx_offset = (self.page - 1) * self.perpage
+    local items_on_current_page = math.min(self.perpage, math.max(0, #self.item_table - idx_offset))
     local line_layout = {}
     local select_number
     if self.recent_boundary_index == nil then self.recent_boundary_index = 0 end
@@ -1330,26 +1331,26 @@ function MosaicMenu:_updateItemsBuildUI()
         -- Draw row separator based on the recent boundary.
         -- If the previous row ends before the boundary → black line.
         -- If boundary falls within the previous row → gray baseline + black overlay over recent columns.
-        -- Otherwise → thin GRAY.
+        -- Otherwise → thin gray.
 
         -- not complete:
         -- for the last row on a page, the full-width line should be COLOR_WHITE (and must be painted)
         -- and if all items in the last row are opened, no COLOR_BLACK line should be painted.
         -- note: the "last" row is sometimes not the same as the "bottom" row (eg: 5 items in a 3x3 grid)
-        -- 
+        --
         -- this way there will only be a black underline if some items in the bottom line are opened
         -- and only shown under those opened books.
         if idx % self.nb_cols == 1 then -- new row
             table.insert(self.item_group, VerticalSpan:new { width = Screen:scaleBySize(half_margin_size) })
-            local prev_row_start = idx_offset + (idx - self.nb_cols)
-            local prev_row_end = idx_offset + (idx - 1)
+            local row_start = index
+            local row_end   = math.min(index + (self.nb_cols - 1), idx_offset + items_on_current_page)
             if self.recent_boundary_index > 0 then
-                if prev_row_end < self.recent_boundary_index then
+                if row_end <= self.recent_boundary_index then
                     table.insert(self.item_group, ptutil.thinBlackLine(line_width))
-                elseif prev_row_start <= self.recent_boundary_index and prev_row_end >= self.recent_boundary_index then
+                elseif row_start <= self.recent_boundary_index and row_end >= self.recent_boundary_index then
                     local pad = Screen:scaleBySize(10)
                     local inner_total = math.max(0, line_width - 2 * pad)
-                    local dark_cols = math.max(0, math.min(self.nb_cols, self.recent_boundary_index - prev_row_start + 1))
+                    local dark_cols = math.max(0, math.min(self.nb_cols, self.recent_boundary_index - row_start + 1))
                     local dark_inner = math.floor(inner_total * (dark_cols / self.nb_cols))
 
                     table.insert(self.item_group, OverlapGroup:new {

--- a/mosaicmenu.lua
+++ b/mosaicmenu.lua
@@ -411,6 +411,7 @@ local MosaicMenuItem = InputContainer:extend {
     cover_specs = nil,
     has_description = false,
     pages = nil,
+    is_boundary_item = false,
 }
 
 function MosaicMenuItem:init()
@@ -897,6 +898,14 @@ function MosaicMenuItem:paintTo(bb, x, y)
     -- Original painting
     InputContainer.paintTo(self, bb, x, y)
 
+    if self.is_boundary_item then
+        local boundary_line = LineWidget:new {
+            dimen = Geom:new { w = Size.border.default, h = self.height },
+            background = Blitbuffer.COLOR_BLACK,
+        }
+        boundary_line:paintTo(bb, x + self.width + (Screen:scaleBySize(margin_size/2)), y)
+    end
+
     -- other paintings are anchored to the sub-widget (cover image)
     local target = self[1][1][1]
 
@@ -1315,6 +1324,7 @@ function MosaicMenu:_updateItemsBuildUI()
             })
             table.insert(cur_row, HorizontalSpan:new({ width = self.item_margin }))
         end
+        local is_boundary_here = (self.recent_boundary_index and self.recent_boundary_index > 0 and index == self.recent_boundary_index)
         local item_tmp = MosaicMenuItem:new {
             height = self.item_height,
             width = self.item_width,
@@ -1326,6 +1336,7 @@ function MosaicMenu:_updateItemsBuildUI()
             menu = self,
             do_cover_image = self._do_cover_images,
             do_hint_opened = self._do_hint_opened,
+            is_boundary_item = is_boundary_here,
         }
         table.insert(cur_row, item_tmp)
         table.insert(cur_row, HorizontalSpan:new({ width = self.item_margin }))

--- a/mosaicmenu.lua
+++ b/mosaicmenu.lua
@@ -1306,7 +1306,7 @@ function MosaicMenu:_updateItemsBuildUI()
                 -- Otherwise → thin GRAY.
                 local prev_row_start = idx_offset + (idx - self.nb_cols)
                 local prev_row_end = idx_offset + (idx - 1)
-                if self.recent_boundary_index and self.recent_boundary_index > 0 then
+                if self.recent_boundary_index > 0 then
                     if prev_row_end < self.recent_boundary_index then
                         table.insert(self.item_group, ptutil.thinBlackLine(line_width))
                     elseif prev_row_start <= self.recent_boundary_index and prev_row_end >= self.recent_boundary_index then

--- a/mosaicmenu.lua
+++ b/mosaicmenu.lua
@@ -1280,7 +1280,7 @@ function MosaicMenu:_updateItemsBuildUI()
     -- Build our grid
     local grid_timer = ptdbg:new()
     local line_width = self.width or self.screen_w
-    table.insert(self.item_group, ptutil.mediumDarkLine(line_width))
+    table.insert(self.item_group, ptutil.mediumBlackLine(line_width))
     local cur_row = nil
     local idx_offset = (self.page - 1) * self.perpage
     local line_layout = {}
@@ -1299,7 +1299,7 @@ function MosaicMenu:_updateItemsBuildUI()
             table.insert(self.item_group, VerticalSpan:new { width = Screen:scaleBySize(half_margin_size) })
             if idx > 1 then
                 table.insert(self.layout, line_layout)
-                table.insert(self.item_group, ptutil.thinLightLine(line_width))
+                table.insert(self.item_group, ptutil.thinGrayLine(line_width))
                 table.insert(self.item_group, VerticalSpan:new { width = Screen:scaleBySize(half_margin_size) })
             end
             line_layout = {}

--- a/mosaicmenu.lua
+++ b/mosaicmenu.lua
@@ -1287,6 +1287,7 @@ function MosaicMenu:_updateItemsBuildUI()
     local idx_offset = (self.page - 1) * self.perpage
     local line_layout = {}
     local select_number
+    if self.recent_boundary_index == nil then self.recent_boundary_index = 0 end
     for idx = 1, self.perpage do
         local itm_timer = ptdbg:new()
         local index = idx_offset + idx

--- a/mosaicmenu.lua
+++ b/mosaicmenu.lua
@@ -1161,9 +1161,8 @@ function MosaicMenu:_recalculateDimen()
     end
 
     self.item_margin = Screen:scaleBySize(margin_size)
-    self.others_height = self.others_height + (Size.line.thin * self.nb_rows) -- lines between items
+    self.others_height = self.others_height + (Size.line.thin * self.nb_rows) -- lines between rows
     self.others_height = self.others_height + ((self.nb_rows + 1) * self.item_margin) -- margins between rows
-    -- self.others_height = self.others_height + Screen:scaleBySize(3) -- bottom padding
 
     -- Set our items target size
     self.item_height = math.floor(
@@ -1300,8 +1299,8 @@ function MosaicMenu:_updateItemsBuildUI()
             select_number = idx
         end
         if idx % self.nb_cols == 1 then -- new row
+            if idx > 1 then table.insert(self.layout, line_layout) end
             line_layout = {}
-            table.insert(self.layout, line_layout)
             cur_row = HorizontalGroup:new {}
             -- Have items on the possibly non-fully filled last row aligned to the left
             local container = self._do_center_partial_rows and CenterContainer or LeftContainer
@@ -1329,14 +1328,9 @@ function MosaicMenu:_updateItemsBuildUI()
         table.insert(cur_row, item_tmp)
         table.insert(cur_row, HorizontalSpan:new({ width = self.item_margin }))
 
-
         -- Recent items that are sorted to top of the library are underlined in black (using the row separator line)
-
-        -- Draw row separator based on the recent boundary.
-        -- If the current row ends before the boundary → full black line.
-        -- If boundary falls within the current row → gray baseline + black overlay over recent columns.
-        -- Otherwise → thin gray.
-
+        -- If the current row ends before the boundary → full black line. If boundary falls within the current
+        -- row → gray baseline + black overlay over recent columns, otherwise → thin gray.
         -- Special case: last line gets a white (invisible) line instead of gray. Logic for black lines is unchanged.
         if idx % self.nb_cols == 1 then -- new row
             table.insert(self.item_group, VerticalSpan:new { width = Screen:scaleBySize(half_margin_size) })
@@ -1369,10 +1363,8 @@ function MosaicMenu:_updateItemsBuildUI()
             end
             table.insert(self.item_group, VerticalSpan:new { width = Screen:scaleBySize(half_margin_size) })
         end
-
         -- this is for focus manager
         table.insert(line_layout, item_tmp)
-
         if not item_tmp.bookinfo_found and not item_tmp.is_directory and not item_tmp.file_deleted then
             -- Register this item for update
             table.insert(self.items_to_update, item_tmp)
@@ -1380,7 +1372,6 @@ function MosaicMenu:_updateItemsBuildUI()
         itm_timer:report("Draw grid item " .. getMenuText(entry))
     end
     table.insert(self.layout, line_layout)
-    -- table.insert(self.item_group, VerticalSpan:new { width = Screen:scaleBySize(3) }) -- bottom padding
     grid_timer:report("Draw cover grid page " .. self.perpage)
     return select_number
 end

--- a/ptutil.lua
+++ b/ptutil.lua
@@ -346,9 +346,9 @@ function ptutil.line(width, color, thickness)
     }
 end
 
-ptutil.thinDarkLine  = function(w) return ptutil.line(w, Blitbuffer.COLOR_BLACK, Size.line.thin) end
-ptutil.thinLightLine = function(w) return ptutil.line(w, Blitbuffer.COLOR_GRAY,  Size.line.thin) end
-ptutil.mediumDarkLine  = function(w) return ptutil.line(w, Blitbuffer.COLOR_BLACK, Size.line.medium) end
+ptutil.thinBlackLine  = function(w) return ptutil.line(w, Blitbuffer.COLOR_BLACK, Size.line.thin) end
+ptutil.thinGrayLine = function(w) return ptutil.line(w, Blitbuffer.COLOR_GRAY,  Size.line.thin) end
+ptutil.mediumBlackLine  = function(w) return ptutil.line(w, Blitbuffer.COLOR_BLACK, Size.line.medium) end
 
 function ptutil.onFocus(_underline_container)
     if not Device:isTouchDevice() or BookInfoManager:getSetting("force_focus_indicator") then

--- a/ptutil.lua
+++ b/ptutil.lua
@@ -335,27 +335,20 @@ function ptutil.getSubfolderCoverImages(filepath, max_w, max_h)
     end
 end
 
-function ptutil.darkLine(width)
+function ptutil.line(width, color, thickness)
     return HorizontalGroup:new {
         HorizontalSpan:new { width = Screen:scaleBySize(10) },
         LineWidget:new {
-            dimen = Geom:new { w = width - Screen:scaleBySize(20), h = Size.line.medium },
-            background = Blitbuffer.COLOR_BLACK,
+            dimen = Geom:new { w = width - Screen:scaleBySize(20), h = thickness },
+            background = color,
         },
         HorizontalSpan:new { width = Screen:scaleBySize(10) },
     }
 end
 
-function ptutil.lightLine(width)
-    return HorizontalGroup:new {
-        HorizontalSpan:new { width = Screen:scaleBySize(10) },
-        LineWidget:new {
-            dimen = Geom:new { w = width - Screen:scaleBySize(20), h = Size.line.thin },
-            background = Blitbuffer.COLOR_GRAY,
-        },
-        HorizontalSpan:new { width = Screen:scaleBySize(10) },
-    }
-end
+ptutil.thinDarkLine  = function(w) return ptutil.line(w, Blitbuffer.COLOR_BLACK, Size.line.thin) end
+ptutil.thinLightLine = function(w) return ptutil.line(w, Blitbuffer.COLOR_GRAY,  Size.line.thin) end
+ptutil.mediumDarkLine  = function(w) return ptutil.line(w, Blitbuffer.COLOR_BLACK, Size.line.medium) end
 
 function ptutil.onFocus(_underline_container)
     if not Device:isTouchDevice() or BookInfoManager:getSetting("force_focus_indicator") then

--- a/ptutil.lua
+++ b/ptutil.lua
@@ -346,8 +346,9 @@ function ptutil.line(width, color, thickness)
     }
 end
 
-ptutil.thinBlackLine  = function(w) return ptutil.line(w, Blitbuffer.COLOR_BLACK, Size.line.thin) end
+ptutil.thinWhiteLine = function(w) return ptutil.line(w, Blitbuffer.COLOR_WHITE,  Size.line.thin) end
 ptutil.thinGrayLine = function(w) return ptutil.line(w, Blitbuffer.COLOR_GRAY,  Size.line.thin) end
+ptutil.thinBlackLine  = function(w) return ptutil.line(w, Blitbuffer.COLOR_BLACK, Size.line.thin) end
 ptutil.mediumBlackLine  = function(w) return ptutil.line(w, Blitbuffer.COLOR_BLACK, Size.line.medium) end
 
 function ptutil.onFocus(_underline_container)


### PR DESCRIPTION
This PR adds a subtle visual indicator between the "Recently opened" books at the top of the library in the List modes.

Changes:
- Draw a darker thin separator where “recent/opened” items end and the normal sorted list begins; the table entries remains unchanged.
- Consolidate line helpers into a single customizable utility.