### PR TITLE
Centralize UI constants in ptutil

### DIFF
--- a/listmenu.lua
+++ b/listmenu.lua
@@ -133,13 +133,13 @@ function ListMenuItem:update()
     end
     -- Will speed up a bit if we don't do all font sizes when
     -- looking for one that make text fit
-    local fontsize_dec_step = ptutil.constants.fontsize_dec_step
+    local fontsize_dec_step = ptutil.list_defaults.fontsize_dec_step
     -- calculate font used in all right widget text
-    local wright_font_size = _fontSize(ptutil.constants.list_wright_font_nominal, ptutil.constants.list_wright_font_max)
+    local wright_font_size = _fontSize(ptutil.list_defaults.wright_font_nominal, ptutil.list_defaults.wright_font_max)
     local wright_font_face = Font:getFace(ptutil.good_sans, wright_font_size)
     -- and font sizes used for title and author/series
-    local title_font_size = _fontSize(ptutil.constants.list_title_font_nominal, ptutil.constants.list_title_font_max)
-    local authors_font_size = _fontSize(ptutil.constants.list_authors_font_nominal, ptutil.constants.list_authors_font_max)
+    local title_font_size = _fontSize(ptutil.list_defaults.title_font_nominal, ptutil.list_defaults.title_font_max)
+    local authors_font_size = _fontSize(ptutil.list_defaults.authors_font_nominal, ptutil.list_defaults.authors_font_max)
 
     -- We'll draw some padding around cover images so they don't run up against
     -- other parts of the list item or decorations
@@ -455,9 +455,9 @@ function ListMenuItem:update()
                 local progressbar_items = { align = "center" }
 
                 local fn_pages = tonumber(est_page_count)
-                local max_progress_size = ptutil.constants.progress_bar_max_size
-                local pixels_per_page = ptutil.constants.progress_bar_pixels_per_page
-                local min_progress_size = ptutil.constants.progress_bar_min_size_list
+                local max_progress_size = ptutil.list_defaults.progress_bar_max_size
+                local pixels_per_page = ptutil.list_defaults.progress_bar_pixels_per_page
+                local min_progress_size = ptutil.list_defaults.progress_bar_min_size
                 local progress_bar_height = wright_font_size -- progress bar same height as progress text
                 local total_pixels = math.max(
                     (math.min(math.floor((fn_pages / pixels_per_page) + 0.5), max_progress_size)), min_progress_size)
@@ -722,8 +722,8 @@ function ListMenuItem:update()
             else
                 title = bookinfo.title and bookinfo.title or filename_without_suffix
                 title = BD.auto(title)
-                local authors_limit = ptutil.constants.authors_limit_default
-                if (show_series and series_mode == "series_in_separate_line") then authors_limit = ptutil.constants.authors_limit_with_series end
+                local authors_limit = ptutil.list_defaults.authors_limit_default
+                if (show_series and series_mode == "series_in_separate_line") then authors_limit = ptutil.list_defaults.authors_limit_with_series end
                 authors = ptutil.formatAuthors(bookinfo.authors, authors_limit)
             end
             -- series name and position (if available, if requested)
@@ -828,7 +828,7 @@ function ListMenuItem:update()
                 }
                 wmetadata_items = { wauthors }
                 if show_tags and formatted_tags then
-                    fontsize_tags = math.max(ptutil.constants.list_tags_font_min, fontsize_authors - ptutil.constants.list_tags_font_offset)
+                    fontsize_tags = math.max(ptutil.list_defaults.tags_font_min, fontsize_authors - ptutil.list_defaults.tags_font_offset)
                     wtags_avail_height = dimen.h - (wtitle and wtitle:getSize().h or 0) - (wauthors and wauthors:getSize().h or 0)
                     wtags = TextBoxWidget:new {
                         text = formatted_tags,
@@ -861,7 +861,7 @@ function ListMenuItem:update()
             local authors_line_height
             local authors_min_height
             local formatted_tags = nil
-            if show_tags then formatted_tags = ptutil.formatTags(bookinfo.keywords, ptutil.constants.list_tags_limit) end
+            if show_tags then formatted_tags = ptutil.formatTags(bookinfo.keywords, ptutil.list_defaults.tags_limit) end
 
             while true do
                 build_wtitle()
@@ -871,7 +871,7 @@ function ListMenuItem:update()
 
                 -- if the single-line title is ... then reduce font to try fitting it
                 while wtitle:isTruncated() do
-                    if fontsize_title <= ptutil.constants.list_title_font_nominal then
+                    if fontsize_title <= ptutil.list_defaults.title_font_nominal then
                         break
                     end
                     fontsize_title = fontsize_title - fontsize_dec_step
@@ -927,7 +927,7 @@ function ListMenuItem:update()
                     title_ismultiline = false
                 else
                     while wtitle:getSize().h + math.max(wmetadata:getSize().h, wright_height) < avail_dimen_h do
-                        if fontsize_title >= ptutil.constants.list_title_font_max then
+                        if fontsize_title >= ptutil.list_defaults.title_font_max then
                             break
                         end
                         fontsize_title = fontsize_title + fontsize_dec_step
@@ -949,7 +949,7 @@ function ListMenuItem:update()
                 authors_width = wmain_width - (wright_width + wright_right_padding)
                 build_wmetadata(authors_width, formatted_tags)
                 while wmetadata:getSize().h > avail_dimen_h - wtitle:getSize().h do
-                    if fontsize_authors <= ptutil.constants.list_authors_font_min then
+                    if fontsize_authors <= ptutil.list_defaults.authors_font_min then
                         break
                     end
                     fontsize_authors = fontsize_authors - fontsize_dec_step

--- a/main.lua
+++ b/main.lua
@@ -375,15 +375,15 @@ function CoverBrowser:addToMainMenu(menu_items)
                         width_factor = 0.6,
                         left_text = _("Columns"),
                         left_value = nb_cols,
-                        left_min = ptutil.constants.min_cols,
-                        left_max = ptutil.constants.max_cols,
-                        left_default = ptutil.constants.default_cols,
+                        left_min = ptutil.grid_defaults.min_cols,
+                        left_max = ptutil.grid_defaults.max_cols,
+                        left_default = ptutil.grid_defaults.default_cols,
                         left_precision = "%01d",
                         right_text = _("Rows"),
                         right_value = nb_rows,
-                        right_min = ptutil.constants.min_rows,
-                        right_max = ptutil.constants.max_rows,
-                        right_default = ptutil.constants.default_rows,
+                        right_min = ptutil.grid_defaults.min_rows,
+                        right_max = ptutil.grid_defaults.max_rows,
+                        right_default = ptutil.list_defaults.default_rows,
                         right_precision = "%01d",
                         keep_shown_on_apply = true,
                         callback = function(left_value, right_value)
@@ -424,15 +424,15 @@ function CoverBrowser:addToMainMenu(menu_items)
                         width_factor = 0.6,
                         left_text = _("Columns"),
                         left_value = nb_cols,
-                        left_min = ptutil.constants.min_cols,
-                        left_max = ptutil.constants.max_cols,
-                        left_default = ptutil.constants.default_cols,
+                        left_min = ptutil.grid_defaults.min_cols,
+                        left_max = ptutil.grid_defaults.max_cols,
+                        left_default = ptutil.grid_defaults.default_cols,
                         left_precision = "%01d",
                         right_text = _("Rows"),
                         right_value = nb_rows,
-                        right_min = ptutil.constants.min_rows,
-                        right_max = ptutil.constants.max_rows,
-                        right_default = ptutil.constants.default_cols,
+                        right_min = ptutil.grid_defaults.min_rows,
+                        right_max = ptutil.grid_defaults.max_rows,
+                        right_default = ptutil.grid_defaults.default_rols,
                         right_precision = "%01d",
                         keep_shown_on_apply = true,
                         callback = function(left_value, right_value)
@@ -464,17 +464,17 @@ function CoverBrowser:addToMainMenu(menu_items)
                     -- default files_per_page should be calculated by ListMenu on the first drawing,
                     -- use 7 if ListMenu has not been drawn yet
                     return _("List modes") .. T(_(": %1"),
-                        fc.files_per_page or ptutil.constants.default_items_per_page)
+                        fc.files_per_page or ptutil.list_defaults.default_items_per_page)
                 end,
                 callback = function()
-                    local files_per_page = fc.files_per_page or ptutil.constants.default_items_per_page
+                    local files_per_page = fc.files_per_page or ptutil.list_defaults.default_items_per_page
                     local SpinWidget = require("ui/widget/spinwidget")
                     local widget = SpinWidget:new {
                         title_text = _("List modes"),
                         value = files_per_page,
-                        value_min = ptutil.constants.min_items_per_page,
-                        value_max = ptutil.constants.max_items_per_page,
-                        default_value = ptutil.constants.default_items_per_page,
+                        value_min = ptutil.list_defaults.min_items_per_page,
+                        value_max = ptutil.list_defaults.max_items_per_page,
+                        default_value = ptutil.list_defaults.default_items_per_page,
                         keep_shown_on_apply = true,
                         callback = function(spin)
                             fc.files_per_page = spin.value
@@ -774,10 +774,10 @@ end
 function CoverBrowser.initGrid(menu, display_mode)
     if menu == nil then return end
     if menu.nb_cols_portrait == nil then
-        menu.nb_cols_portrait  = BookInfoManager:getSetting("nb_cols_portrait") or ptutil.constants.default_cols
-        menu.nb_rows_portrait  = BookInfoManager:getSetting("nb_rows_portrait") or ptutil.constants.default_rows
-        menu.nb_cols_landscape = BookInfoManager:getSetting("nb_cols_landscape") or ptutil.constants.default_cols
-        menu.nb_rows_landscape = BookInfoManager:getSetting("nb_rows_landscape") or ptutil.constants.default_rows
+        menu.nb_cols_portrait  = BookInfoManager:getSetting("nb_cols_portrait") or ptutil.grid_defaults.default_cols
+        menu.nb_rows_portrait  = BookInfoManager:getSetting("nb_rows_portrait") or ptutil.list_defaults.default_rows
+        menu.nb_cols_landscape = BookInfoManager:getSetting("nb_cols_landscape") or ptutil.grid_defaults.default_cols
+        menu.nb_rows_landscape = BookInfoManager:getSetting("nb_rows_landscape") or ptutil.list_defaults.default_rows
         -- initial List mode files_per_page will be calculated and saved by ListMenu on the first drawing
         menu.files_per_page    = BookInfoManager:getSetting("files_per_page")
     end
@@ -1074,8 +1074,8 @@ function CoverBrowser:onIncreaseItemsPerPage()
     local display_mode = BookInfoManager:getSetting("filemanager_display_mode")
     -- list modes
     if display_mode == "list_image_meta" or display_mode == "list_only_meta" or display_mode == "list_no_meta" then
-        local files_per_page = fc.files_per_page or ptutil.constants.default_items_per_page
-        files_per_page = math.min(files_per_page + 1, ptutil.constants.max_items_per_page)
+        local files_per_page = fc.files_per_page or ptutil.list_defaults.default_items_per_page
+        files_per_page = math.min(files_per_page + 1, ptutil.list_defaults.max_items_per_page)
         BookInfoManager:saveSetting("files_per_page", files_per_page)
         FileChooser.files_per_page = files_per_page
         -- grid mode
@@ -1084,11 +1084,11 @@ function CoverBrowser:onIncreaseItemsPerPage()
         local Screen = Device.screen
         local portrait_mode = Screen:getWidth() <= Screen:getHeight()
         if portrait_mode then
-            local portrait_cols = BookInfoManager:getSetting("nb_cols_portrait") or ptutil.constants.default_cols
-            local portrait_rows = BookInfoManager:getSetting("nb_rows_portrait") or ptutil.constants.default_rows
+            local portrait_cols = BookInfoManager:getSetting("nb_cols_portrait") or ptutil.grid_defaults.default_cols
+            local portrait_rows = BookInfoManager:getSetting("nb_rows_portrait") or ptutil.list_defaults.default_rows
             if portrait_cols == portrait_rows then
-                fc.nb_cols_portrait = math.min(portrait_cols + 1, ptutil.constants.max_cols)
-                fc.nb_rows_portrait = math.min(portrait_rows + 1, ptutil.constants.max_rows)
+                fc.nb_cols_portrait = math.min(portrait_cols + 1, ptutil.grid_defaults.max_cols)
+                fc.nb_rows_portrait = math.min(portrait_rows + 1, ptutil.grid_defaults.max_rows)
                 BookInfoManager:saveSetting("nb_cols_portrait", fc.nb_cols_portrait)
                 BookInfoManager:saveSetting("nb_rows_portrait", fc.nb_rows_portrait)
                 FileChooser.nb_cols_portrait = fc.nb_cols_portrait
@@ -1096,11 +1096,11 @@ function CoverBrowser:onIncreaseItemsPerPage()
             end
         end
         if not portrait_mode then
-            local landscape_cols = BookInfoManager:getSetting("nb_cols_landscape") or ptutil.constants.default_cols
-            local landscape_rows = BookInfoManager:getSetting("nb_rows_landscape") or ptutil.constants.default_rows
+            local landscape_cols = BookInfoManager:getSetting("nb_cols_landscape") or ptutil.grid_defaults.default_cols
+            local landscape_rows = BookInfoManager:getSetting("nb_rows_landscape") or ptutil.list_defaults.default_rows
             if landscape_cols == landscape_rows then
-                fc.nb_cols_landscape = math.min(landscape_cols + 1, ptutil.constants.max_cols)
-                fc.nb_rows_landscape = math.min(landscape_rows + 1, ptutil.constants.max_rows)
+                fc.nb_cols_landscape = math.min(landscape_cols + 1, ptutil.grid_defaults.max_cols)
+                fc.nb_rows_landscape = math.min(landscape_rows + 1, ptutil.grid_defaults.max_rows)
                 BookInfoManager:saveSetting("nb_cols_landscape", fc.nb_cols_landscape)
                 BookInfoManager:saveSetting("nb_rows_landscape", fc.nb_rows_landscape)
                 FileChooser.nb_cols_landscape = fc.nb_cols_landscape
@@ -1118,8 +1118,8 @@ function CoverBrowser:onDecreaseItemsPerPage()
     local display_mode = BookInfoManager:getSetting("filemanager_display_mode")
     -- list modes
     if display_mode == "list_image_meta" or display_mode == "list_only_meta" or display_mode == "list_no_meta" then
-        local files_per_page = fc.files_per_page or ptutil.constants.default_items_per_page
-        files_per_page = math.max(files_per_page - 1, ptutil.constants.min_items_per_page)
+        local files_per_page = fc.files_per_page or ptutil.list_defaults.default_items_per_page
+        files_per_page = math.max(files_per_page - 1, ptutil.list_defaults.min_items_per_page)
         BookInfoManager:saveSetting("files_per_page", files_per_page)
         FileChooser.files_per_page = files_per_page
         -- grid mode
@@ -1128,11 +1128,11 @@ function CoverBrowser:onDecreaseItemsPerPage()
         local Screen = Device.screen
         local portrait_mode = Screen:getWidth() <= Screen:getHeight()
         if portrait_mode then
-            local portrait_cols = BookInfoManager:getSetting("nb_cols_portrait") or ptutil.constants.default_cols
-            local portrait_rows = BookInfoManager:getSetting("nb_rows_portrait") or ptutil.constants.default_rows
+            local portrait_cols = BookInfoManager:getSetting("nb_cols_portrait") or ptutil.grid_defaults.default_cols
+            local portrait_rows = BookInfoManager:getSetting("nb_rows_portrait") or ptutil.list_defaults.default_rows
             if portrait_cols == portrait_rows then
-                fc.nb_cols_portrait = math.max(portrait_cols - 1, ptutil.constants.min_cols)
-                fc.nb_rows_portrait = math.max(portrait_rows - 1, ptutil.constants.min_rows)
+                fc.nb_cols_portrait = math.max(portrait_cols - 1, ptutil.grid_defaults.min_cols)
+                fc.nb_rows_portrait = math.max(portrait_rows - 1, ptutil.grid_defaults.min_rows)
                 BookInfoManager:saveSetting("nb_cols_portrait", fc.nb_cols_portrait)
                 BookInfoManager:saveSetting("nb_rows_portrait", fc.nb_rows_portrait)
                 FileChooser.nb_cols_portrait = fc.nb_cols_portrait
@@ -1140,11 +1140,11 @@ function CoverBrowser:onDecreaseItemsPerPage()
             end
         end
         if not portrait_mode then
-            local landscape_cols = BookInfoManager:getSetting("nb_cols_landscape") or ptutil.constants.default_cols
-            local landscape_rows = BookInfoManager:getSetting("nb_rows_landscape") or ptutil.constants.default_rows
+            local landscape_cols = BookInfoManager:getSetting("nb_cols_landscape") or ptutil.grid_defaults.default_cols
+            local landscape_rows = BookInfoManager:getSetting("nb_rows_landscape") or ptutil.list_defaults.default_rows
             if landscape_cols == landscape_rows then
-                fc.nb_cols_landscape = math.max(landscape_cols - 1, ptutil.constants.min_cols)
-                fc.nb_rows_landscape = math.max(landscape_rows - 1, ptutil.constants.min_rows)
+                fc.nb_cols_landscape = math.max(landscape_cols - 1, ptutil.grid_defaults.min_cols)
+                fc.nb_rows_landscape = math.max(landscape_rows - 1, ptutil.grid_defaults.min_rows)
                 BookInfoManager:saveSetting("nb_cols_landscape", fc.nb_cols_landscape)
                 BookInfoManager:saveSetting("nb_rows_landscape", fc.nb_rows_landscape)
                 FileChooser.nb_cols_landscape = fc.nb_cols_landscape

--- a/mosaicmenu.lua
+++ b/mosaicmenu.lua
@@ -543,13 +543,13 @@ function MosaicMenuItem:update()
                     forced_baseline = baseline,
                 }
             end
-            local dirtext_font_size = 22
+            local dirtext_font_size = ptutil.grid_defaults.dir_font_nominal
             build_directory_text(dirtext_font_size)
             local directory_text_height = directory_text:getSize().h
             local directory_text_baseline = directory_text:getBaseline()
-            while dirtext_font_size >= 18 do
+            while dirtext_font_size > ptutil.grid_defaults.dir_font_min do
                 if directory_text:isTruncated() then
-                    dirtext_font_size = dirtext_font_size - 1
+                    dirtext_font_size = math.min(dirtext_font_size - ptutil.grid_defaults.fontsize_dec_step, ptutil.grid_defaults.dir_font_min)
                     build_directory_text(dirtext_font_size, directory_text_height, directory_text_baseline)
                 else
                     break
@@ -957,9 +957,9 @@ function MosaicMenuItem:paintTo(bb, x, y)
             local large_book = false
             if est_page_count then
                 local fn_pages = tonumber(est_page_count)
-                local max_progress_size = ptutil.constants.progress_bar_max_size
-                local pixels_per_page = ptutil.constants.progress_bar_pixels_per_page
-                local min_progress_size = ptutil.constants.progress_bar_min_size_mosaic
+                local max_progress_size = ptutil.grid_defaults.progress_bar_max_size
+                local pixels_per_page = ptutil.grid_defaults.progress_bar_pixels_per_page
+                local min_progress_size = ptutil.grid_defaults.progress_bar_min_size
                 local total_pixels = math.max(
                 (math.min(math.floor((fn_pages / pixels_per_page) + 0.5), max_progress_size)), min_progress_size)
                 progress_widget_width_mult = total_pixels / max_progress_size

--- a/ptutil.lua
+++ b/ptutil.lua
@@ -47,38 +47,53 @@ ptutil.separator = {
 }
 
 -- These values control various UI behaviors throughout Project: Title
-ptutil.constants = {
-    -- Progress bar settings (used in both list and mosaic views)
+ptutil.list_defaults = {
+    -- Progress bar settings
     progress_bar_max_size = 235,       -- maximum progress bar width in pixels
     progress_bar_pixels_per_page = 3,  -- pixels per page for progress bar calculation
-    progress_bar_min_size_list = 25,   -- minimum progress bar width in pixels (list view)
-    progress_bar_min_size_mosaic = 40, -- minimum progress bar width in pixels (mosaic view)
+    progress_bar_min_size = 25,       -- minimum progress bar width in pixels
+
+    -- Author display settings
+    authors_limit_default = 2,     -- maximum number of authors to show
+    authors_limit_with_series = 1, -- maximum authors when series is also shown on separate line
 
     -- Font size adjustment step (used when fitting text into available space)
     fontsize_dec_step = 2, -- font size decrement step when adjusting to fit
 
-    -- Author display settings
-    authors_limit_default = 2,     -- maximum number of authors to show in list view
-    authors_limit_with_series = 1, -- maximum authors when series is also shown on separate line
+    -- Font size ranges (nominal sizes based on 64px item height)
+    title_font_nominal = 20,   -- nominal title font size
+    title_font_max = 26,       -- maximum title font size
+    title_font_min = 20,       -- minimum title font size
+    authors_font_nominal = 14, -- nominal authors/metadata font size
+    authors_font_max = 18,     -- maximum authors font size
+    authors_font_min = 10,     -- minimum authors font size
+    wright_font_nominal = 12,  -- nominal right widget font size
+    wright_font_max = 18,      -- maximum right widget font size
+    tags_font_min = 10,        -- minimum tags font size
+    tags_font_offset = 3,      -- offset from authors font size for tags
 
-    -- Font size ranges for list view (nominal sizes based on 64px item height)
-    list_title_font_nominal = 20,   -- nominal title font size
-    list_title_font_max = 26,       -- maximum title font size
-    list_title_font_min = 20,       -- minimum title font size
-    list_authors_font_nominal = 14, -- nominal authors/metadata font size
-    list_authors_font_max = 18,     -- maximum authors font size
-    list_authors_font_min = 10,     -- minimum authors font size
-    list_wright_font_nominal = 12,  -- nominal right widget font size
-    list_wright_font_max = 18,      -- maximum right widget font size
-    list_tags_font_min = 10,        -- minimum tags font size
-    list_tags_font_offset = 3,      -- offset from authors font size for tags
+    tags_limit = 9999,    -- limits the number of tags displayed when enabled
 
-    list_tags_limit = 9999,         -- limits the number of tags displayed in list view.
-
-    -- Grid/list page size limits
+    -- Page item limits
     max_items_per_page = 10,
     min_items_per_page = 3,
     default_items_per_page = 7,
+}
+
+ptutil.grid_defaults = {
+    -- Progress bar settings
+    progress_bar_max_size = ptutil.list_defaults.progress_bar_max_size,               -- maximum progress bar width in pixels
+    progress_bar_pixels_per_page = ptutil.list_defaults.progress_bar_pixels_per_page, -- pixels per page for progress bar calculation
+    progress_bar_min_size = 40,                                                       -- minimum progress bar width in pixels
+
+
+    fontsize_dec_step = 1, -- font size decrement step when adjusting to fit
+
+    -- Font size ranges (nominal sizes based on 64px item height)
+    dir_font_nominal = 22,   -- nominal directory font size
+    dir_font_min = 18,   -- minimum directory font size
+
+    -- Page item limits
     max_cols = 4,
     max_rows = 4,
     min_cols = 2,


### PR DESCRIPTION
Hi Joshua,

I am working on a collection of user patches and moving all those hardcoded constants into ptutil would make customizing them with patches a lot easier. 
There are probably a lot more constants, but these are the ones I would like to modify (for now). 
I hope I found all of the instances where these constants where used. 
Would you mind taking a look at these changes?

Thank you