### PR TITLE
fix: Use sidecar page count as fallback for previously opened books

### DIFF
--- a/listmenu.lua
+++ b/listmenu.lua
@@ -447,10 +447,13 @@ function ListMenuItem:update()
             local wright_width = 0
             local wright_height = 0
             local wright_items = { align = "right" }
-            local est_page_count, draw_progressbar = ptutil.showProgressBar(bookinfo.pages)
+            local pages = bookinfo.pages -- prefer value in database
+            if not pages and book_info and book_info.pages then
+                pages = book_info.pages -- fallback to sidecar metadata
+            end
+
+            local est_page_count, draw_progressbar = ptutil.showProgressBar(pages)
             self.pages = est_page_count
-            bookinfo.pages = est_page_count
-            local pages = bookinfo.pages -- limit to value in database
 
             if draw_progressbar then
                 local progressbar_items = { align = "center" }

--- a/mosaicmenu.lua
+++ b/mosaicmenu.lua
@@ -743,7 +743,11 @@ function MosaicMenuItem:update()
             self.percent_finished = percent_finished
             local status = book_info.status
             self.status = status
-            self.pages, self.show_progress_bar = ptutil.showProgressBar(bookinfo.pages)
+            local pages = bookinfo.pages -- prefer value in database
+            if not pages and book_info and book_info.pages then
+                pages = book_info.pages -- fallback to sidecar metadata
+            end
+            self.pages, self.show_progress_bar = ptutil.showProgressBar(pages)
             local cover_bb_used = false
             self.bookinfo_found = true
             -- For wikipedia saved as epub, we made a cover from the 1st pic of the page,


### PR DESCRIPTION
Addresses #113 (for previously opened books)

## Problem

Currently, page counts only display if the user has either:
1. Set up Calibre's Count Pages plugin (writes to EPUB OPF metadata)
2. Added a `P(xxx)` suffix to the filename

If neither is configured, no page count is shown, even when KOReader has already calculated and stored an accurate page count in the book's sidecar metadata.

## Solution

Fall back to `book_info.pages` (from sidecar) when `bookinfo.pages` (from database) is nil:

```lua
local pages = bookinfo.pages
if not pages and book_info and book_info.pages then
    pages = book_info.pages
end
```

Note the two different variables here:
- `bookinfo.pages` — from the ProjectTitle database (Calibre/filename sources)
- `book_info.pages` — from KOReader's sidecar metadata

Database values always take priority, so existing Calibre setups are unaffected.

## Scope

This only provides page counts for books the user has **previously opened**, since KOReader writes sidecar data on first open. Unopened books still won't have page counts unless Calibre or the filename method is used.

No performance impact because this just reads data that already exists.

## Other changes

Removes a line that was overwriting `bookinfo.pages` with estimated values, which could replace accurate page counts with less reliable estimates.