### PR TITLE
feat: add explicit cover path support to getFolderCover()

### DIFF
--- a/listmenu.lua
+++ b/listmenu.lua
@@ -219,7 +219,7 @@ function ListMenuItem:update()
         if self.do_cover_image and is_pathchooser == false then
             local subfolder_cover_image
             -- check for folder image
-            subfolder_cover_image = ptutil.getFolderCover(self.filepath, max_img_w * 0.82, max_img_h)
+            subfolder_cover_image = ptutil.getFolderCover(self.filepath, max_img_w * 0.82, max_img_h, self.entry.pt_cover_path)
             -- check for books with covers in the subfolder
             if subfolder_cover_image == nil and not BookInfoManager:getSetting("disable_auto_foldercovers") then
                 subfolder_cover_image = ptutil.getSubfolderCoverImages(self.filepath, max_img_w, max_img_h)

--- a/mosaicmenu.lua
+++ b/mosaicmenu.lua
@@ -502,7 +502,7 @@ function MosaicMenuItem:update()
         if is_pathchooser == false then
             local subfolder_cover_image
             -- check for folder image
-            subfolder_cover_image = ptutil.getFolderCover(self.filepath, dimen.w, dimen.h)
+            subfolder_cover_image = ptutil.getFolderCover(self.filepath, dimen.w, dimen.h, self.entry.pt_cover_path)
             -- check for books with covers in the subfolder
             if subfolder_cover_image == nil and not BookInfoManager:getSetting("disable_auto_foldercovers") then
                 subfolder_cover_image = ptutil.getSubfolderCoverImages(self.filepath, max_img_w, max_img_h)

--- a/ptutil.lua
+++ b/ptutil.lua
@@ -258,8 +258,19 @@ local function findCover(dir_path)
     return nil
 end
 
-function ptutil.getFolderCover(filepath, max_img_w, max_img_h)
-    local folder_image_file = findCover(filepath)
+---
+--- Gets a folder cover image widget.
+--- @param filepath string: Path to the folder.
+--- @param max_img_w number: Maximum image width.
+--- @param max_img_h number: Maximum image height.
+--- @param pt_cover_path string|nil: Optional explicit cover path for ProjectTitle (e.g., from virtual folders).
+--- @return table|nil: FrameContainer with image widget, or nil if no cover found.
+function ptutil.getFolderCover(filepath, max_img_w, max_img_h, pt_cover_path)
+    local folder_image_file = pt_cover_path
+
+    if not folder_image_file then
+        folder_image_file = findCover(filepath)
+    end
     if folder_image_file ~= nil then
         local success, folder_image = pcall(function()
             local temp_image = ImageWidget:new { file = folder_image_file, scale_factor = 1 }


### PR DESCRIPTION
Enable virtual folders to specify explicit cover
paths instead of auto-detecting them. This improves cover image handling for custom folder structures.

- Add pt_cover_path parameter to getFolderCover() function
- Use explicit cover path if provided, otherwise auto-detect
- Update listmenu.lua and mosaicmenu.lua to pass cover paths
- Add documentation to getFolderCover() function

Change-Id: 3d41071731f5730bb12738607689477b
Change-Id-Short: wmvyzsyswyku
Relates-To: https://github.com/OGKevin/kobo.koplugin/pull/189
Fixes: https://github.com/joshuacant/ProjectTitle/issues/162

---
<details><summary>Screenshots</summary>
<p>
😏 

| Header | Header |
|--------|--------|
| <img width="1398" height="1657" alt="Image" src="https://github.com/user-attachments/assets/d987bc7c-e014-45c6-bbd3-5f91eb198edd" /> | <img width="1398" height="1657" alt="Image" src="https://github.com/user-attachments/assets/ea78da47-5243-4209-8408-b0efc1814670" /> | 





</p>
</details> 