### PR TITLE
Allow folder icons for night (dark) and light mode

### DIFF
--- a/ptutil.lua
+++ b/ptutil.lua
@@ -246,10 +246,12 @@ local function findCover(dir_path)
     dir_path = dir_path:gsub("[/\\]+$", "")
     if not util.directoryExists(dir_path) then return nil end
 
+    local mode_pat = G_reader_settings:isTrue("night_mode") and "_dark" or "_light"
+
     local fn_lc
     for fn in lfs.dir(dir_path) do
         fn_lc = fn:lower()
-        if fn_lc:match('^%.?cover%.') or fn_lc:match('^%.?folder%.') then
+        if fn_lc:match('^%.?cover%.') or fn_lc:match('^%.?folder%.') or fn_lc:match('^%.?cover' .. mode_pat .. '%.') or fn_lc:match('^%.?folder' .. mode_pat .. '%.') then
             if fn_lc:match('%.jpe?g$') or fn_lc:match('%.png$') or fn_lc:match('%.webp$') or fn_lc:match('%.gif$') then
                 return dir_path .. "/" .. fn
             end


### PR DESCRIPTION
On some devices a clear background isn't supported (rendered as black). So a white/black should be included (which only matches in one mode).

Also some users might want folder images for night mode to be dimmed.

This commit allows to either provide a `folder.png` or (`folder_dark.png` AND `folder_light.png`). (Also `cover` and with leading `.`)

It's undefined what image would be used when e.g. `folder.png` and `folder_dark.png` is present in night mode.

When switching to night mode the images aren't automatically re-rendered. They will be swapped the next time the view is rendered.

I also considered `_night` and `_day` but found dark and light to be more common in mobile development.