### PR TITLE
Compability with (only) KOReader 2027.07.1

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -52,7 +52,7 @@ end
 
     https://github.com/joshuacant/ProjectTitle/wiki/Use-With-Nightly-KOReader-Builds
 --]]
-local safe_version = 202607000000
+local safe_version = 202607010000
 local cv_int, cv_commit = Version:getNormalizedCurrentVersion()
 local version_unsafe = true
 if (cv_int == safe_version or util.fileExists(data_dir .. "/settings/pt-skipversioncheck.txt")) then


### PR DESCRIPTION
Replaced the version code to math KOReader 2026.07.1 - tested on Kindle Paperwhite (I think) 11.

I am not sure if this is how the repo handles version changes, so feel free to help. ^^