### PR TITLE
Read opf via ffi/archiver instead of shelling out to unzip

### DIFF
--- a/bookinfomanager.lua
+++ b/bookinfomanager.lua
@@ -1,3 +1,4 @@
+local Archiver = require("ffi/archiver")
 local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local DataStorage = require("datastorage")
@@ -618,42 +619,24 @@ function BookInfoManager:extractBookInfo(filepath, cover_specs)
                         return nil
                     end
 
-                    local opf_file = nil
-                    local locate_opf_command = "unzip " .. "-lqq \"" .. fname
-                    local opf_match_pattern = "(%S+%.opf)$"
-                    local line = ""
-
-                    -- fh style for Android
-                    if Device:isAndroid() then
-                        -- android unzip binary doesn't always have wildcard support
-                        locate_opf_command = locate_opf_command .. "\""
-                        logger.dbg(ptdbg.logprefix, locate_opf_command)
-                        local fh = io.popen(locate_opf_command, "r")
-                        while true and fh ~= nil do
-                            line = fh:read()
-                            if line == nil or opf_file ~= nil then
+                    -- Read calibre's #pages custom column out of the book's opf via
+                    -- KOReader's archiver (libarchive), not the platform "unzip" binary:
+                    -- unzip isn't present on every device and aborts on some (e.g. Onyx's
+                    -- ubsan-hardened build) when an epub has a zeroed zip timestamp.
+                    local opf_content = nil
+                    local arc = Archiver.Reader:new()
+                    if arc:open(fname) then
+                        for entry in arc:iterate() do
+                            if entry.mode == "file" and string.match(entry.path, "%.opf$") then
+                                logger.dbg(ptdbg.logprefix, "reading opf from archive", entry.path)
+                                opf_content = arc:extractToMemory(entry.path)
                                 break
                             end
-                            opf_file = string.match(line, opf_match_pattern)
-                            logger.dbg(ptdbg.logprefix, line)
                         end
-                    -- std_out style for POSIX
-                    else
-                        local std_out = nil
-                        -- non-android (kobo, kindle, etc?) unzip seems to have wildcard support
-                        locate_opf_command = locate_opf_command .. "\" \"*.opf\""
-                        logger.dbg(ptdbg.logprefix, locate_opf_command)
-                        std_out = io.popen(locate_opf_command)
-                        if std_out then
-                            line = std_out:read()
-                            opf_file = string.match(line, opf_match_pattern)
-                            logger.dbg(ptdbg.logprefix, line)
-                            std_out:close()
-                        end
+                        arc:close()
                     end
 
-                    if opf_file then
-                        local expand_opf_command = "unzip " .. "-p \"" .. fname .. "\" " .. "\"" .. opf_file .. "\""
+                    if opf_content then
                         local found_pages = nil
                         local found_value = nil
                         local do_break = false
@@ -684,27 +667,9 @@ function BookInfoManager:extractBookInfo(filepath, cover_specs)
                             return fp, fv, false
                         end
 
-                        -- fh style for Android
-                        if Device:isAndroid() then
-                            local fh = io.popen(expand_opf_command, "r")
-                            while true and fh ~= nil do
-                                line = fh:read()
-                                if line == nil then
-                                    break
-                                end
-                                found_pages, found_value, do_break = parse_opf_file(found_pages, found_value, line)
-                                if do_break then break end
-                            end
-                        -- std_out style for POSIX
-                        else
-                            local std_out = io.popen(expand_opf_command)
-                            if std_out then
-                                for std_line in std_out:lines() do
-                                    found_pages, found_value, do_break = parse_opf_file(found_pages, found_value, std_line)
-                                    if do_break then break end
-                                end
-                                std_out:close()
-                            end
+                        for opf_line in util.gsplit(opf_content, "\n", false) do
+                            found_pages, found_value, do_break = parse_opf_file(found_pages, found_value, opf_line)
+                            if do_break then break end
                         end
 
                         if found_value and found_value ~= "0" then


### PR DESCRIPTION
## What

Replace the platform `unzip` shell-out in `getEstimatedPagecount` (used to read calibre's `#pages` custom column out of an epub's `.opf`) with KOReader's bundled archiver, `ffi/archiver` (libarchive).

## Why

The current code runs the device's `unzip` binary twice per epub — `unzip -lqq` to locate the `.opf`, then `unzip -p` to read it. That external binary isn't reliable across devices:

- It isn't guaranteed present, and busybox's `unzip` has needed workarounds before (`dd2c67d`).
- On **Onyx** devices the system `unzip` is compiled with the unsigned-overflow sanitizer. Listing an epub whose zip entries carry a **zeroed DOS timestamp** (month field `0`) makes `ZipEntry::GetModificationTime()` evaluate `0u - 1`, and the sanitizer aborts the process:

  ```
  Abort message: 'ubsan: sub-overflow'
  #03 ZipEntry::GetModificationTime() const
  #04 /system/bin/unzip
  ```

  The abort is contained to the spawned `unzip` child, so it doesn't necessarily take KOReader down — but the `.opf` is never read, so the page count is **silently dropped** for that book, and it spams the system crash log. Such epubs are common — anything zipped without a timestamp (e.g. calibre-exported books) lists as `00-00-1980` and trips it.

`ffi/archiver` is already used elsewhere in KOReader (e.g. the Archive viewer plugin), needs no external binary, and doesn't parse zip timestamps, so it sidesteps this entire class of `unzip` problem. It also lets the Android/POSIX command branching go away.

## Changes

- Add `local Archiver = require("ffi/archiver")`.
- Locate + read the `.opf` via `Archiver.Reader` (`open` → `iterate` → `extractToMemory`).
- Feed the extracted opf to the **unchanged** `parse_opf_file` via `util.gsplit(opf_content, "\n", false)`.
- Net `-54/+21` lines.

## Testing

- `luajit -bl bookinfomanager.lua` — clean.
- Ran the new `gsplit` + `parse_opf_file` path over the real `.opf` of two calibre epubs with zeroed timestamps (the ones that abort Onyx's `unzip`): page counts came out `436` and `396`, matching the opf metadata.
- Verified via `bsdtar` (same libarchive engine as `ffi/archiver`) that both files list and extract their `.opf` cleanly where the platform `unzip` aborts.
- **On an Onyx Poke3**: cleared the cached bookinfo row for one of these epubs and used *Refresh cached book information* with this patch. Extraction completed cleanly (`in_progress=0`, not marked unsupported), KOReader's `crash.log` stayed empty, no `unzip`/ubsan abort in logcat, and the cached `pages` now reads `436` — where the old `unzip` path left it `NULL`.
